### PR TITLE
MvNormal: fix missing (), add tests.

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -217,7 +217,7 @@ type FitMvNormal{W<:Weight} <: DistributionStat{VectorInput}
     value::Ds.MvNormal
     cov::CovMatrix{W}
 end
-function FitMvNormal(p::Integer, wgt::Weight = EqualWeight)
+function FitMvNormal(p::Integer, wgt::Weight = EqualWeight())
     FitMvNormal(Ds.MvNormal(zeros(p), eye(p)), CovMatrix(p, wgt))
 end
 nobs(o::FitMvNormal) = nobs(o.cov)

--- a/test/testfiles/distributions_test.jl
+++ b/test/testfiles/distributions_test.jl
@@ -83,6 +83,7 @@ end
     @test nobs(o) == 100
 end
 @testset "MvNormal" begin
+    ## constructor using a vector of values
     y = rand(MvNormal(zeros(4), diagm(ones(4))), 100)'
     o = FitMvNormal(y)
     @test mean(o) ≈ vec(mean(y, 1))
@@ -90,6 +91,20 @@ end
     @test std(o) ≈ vec(std(y, 1))
     @test cov(o) ≈ cov(y)
     @test nobs(o) == 100
+
+    ## empty costructor 
+    z = MvNormal([1, 2], 3)
+    o = FitMvNormal(size(z)[1])
+    N = 100000
+    for _ in 1:N
+        fit!(o, rand(z))
+    end
+    z2 = value(o)
+    # tolerances are generous, but there is a small probability that this
+    # stochastic test will fail occasionally. in that case, rerun.
+    @test nobs(o) == N
+    @test isapprox(mean(z2), mean(z), atol=0.1)
+    @test isapprox(var(z2), var(z), atol=0.1)
 end
 @testset "NormalMix" begin
     d = MixtureModel(Normal, [(0,1), (2,3), (4,5)])

--- a/test/testfiles/multivariate_test.jl
+++ b/test/testfiles/multivariate_test.jl
@@ -1,14 +1,34 @@
 module MultivariateTest
 using OnlineStats, Base.Test
+using Distributions
 
 @testset "Multivariate" begin
-@testset "KMeans" begin
-    x = vcat(randn(1000, 5), 10 + randn(1000, 5))
-    o = KMeans(x, 2)
-    o = KMeans(x, 2, 10)
 
-    @test nobs(o)       == 2000
-    @test size(o.value) == (5, 2)
+    @testset "KMeans" begin
+        x = vcat(randn(1000, 5), 10 + randn(1000, 5))
+        o = KMeans(x, 2)
+        o = KMeans(x, 2, 10)
+        
+        @test nobs(o)       == 2000
+        @test size(o.value) == (5, 2)
+    end
+
+    @testset "MvNormal" begin
+        z = MvNormal([1, 2], 3)
+        o = FitMvNormal(size(z)[1])
+        N = 100000
+        for _ in 1:N
+                fit!(o, rand(z))
+        end
+        z2 = value(o)
+
+        # tolerances are generous, but there is a small probability that this
+        # stochastic test will fail occasionally. in that case, rerun.
+        @test nobs(o) == N
+        @test isapprox(mean(z2), mean(z), atol=0.1)
+        @test isapprox(var(z2), var(z), atol=0.1)
+    end
+
 end
-end
+
 end#module

--- a/test/testfiles/multivariate_test.jl
+++ b/test/testfiles/multivariate_test.jl
@@ -13,22 +13,6 @@ using Distributions
         @test size(o.value) == (5, 2)
     end
 
-    @testset "MvNormal" begin
-        z = MvNormal([1, 2], 3)
-        o = FitMvNormal(size(z)[1])
-        N = 100000
-        for _ in 1:N
-                fit!(o, rand(z))
-        end
-        z2 = value(o)
-
-        # tolerances are generous, but there is a small probability that this
-        # stochastic test will fail occasionally. in that case, rerun.
-        @test nobs(o) == N
-        @test isapprox(mean(z2), mean(z), atol=0.1)
-        @test isapprox(var(z2), var(z), atol=0.1)
-    end
-
 end
 
 end#module


### PR DESCRIPTION
One of the constructors was missing a () for EqualWeight, fixed that.

Added tests for MvNormal.