### PR TITLE
Fix the invalid subtyping error for HyperLogLog, update sqrt, sumabs2, Array(T, m)

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -221,7 +221,7 @@ function FitMvNormal(p::Integer, wgt::Weight = EqualWeight())
     FitMvNormal(Ds.MvNormal(zeros(p), eye(p)), CovMatrix(p, wgt))
 end
 nobs(o::FitMvNormal) = nobs(o.cov)
-Base.std(d::FitMvNormal) = sqrt(var(d))  # No std() method from Distributions?
+Base.std(d::FitMvNormal) = sqrt.(var(d))  # No std() method from Distributions?
 _fit!{T<:Real}(o::FitMvNormal, y::AVec{T}, γ::Float64) = _fit!(o.cov, y, γ)
 function value(o::FitMvNormal)
     c = cov(o.cov)

--- a/src/multivariate/kmeans.jl
+++ b/src/multivariate/kmeans.jl
@@ -37,7 +37,7 @@ function _fit!{T<:Real}(o::KMeans, x::AVec{T}, γ::Float64)
     d, k = size(o.value)
     @assert length(x) == d
     for j in 1:k
-        o.v[j] = sumabs2(x - col(o.value, j))
+        o.v[j] = sum(abs2, x - col(o.value, j))
     end
     kstar = indmin(o.v)
     for i in 1:d
@@ -49,7 +49,7 @@ function _fitbatch!{T<:Real}(o::KMeans, x::AMat{T}, γ::Float64)
     @assert size(x, 2) == d
     x̄ = vec(mean(x, 1))
     for j in 1:k
-        o.v[j] = sumabs2(x̄ - col(o.value, j))
+        o.v[j] = sum(abs2, x̄ - col(o.value, j))
     end
     kstar = indmin(o.v)
     for i in 1:d

--- a/src/streamstats/bootstrap.jl
+++ b/src/streamstats/bootstrap.jl
@@ -25,7 +25,7 @@ end
 
 function BernoulliBootstrap{T <: ScalarInput}(o::OnlineStat{T}, f::Function, r::Int = 1_000)
     replicates = OnlineStat{T}[copy(o) for i in 1:r]
-    cached_state = Array(Float64, r)
+    cached_state = Array{Float64}(r)
     return BernoulliBootstrap(replicates, cached_state, f, 0, true)
 end
 
@@ -61,7 +61,7 @@ type ScalarPoissonBootstrap{S <: OnlineStat{ScalarInput}} <: Bootstrap{ScalarInp
 end
 function PoissonBootstrap{T <: ScalarInput}(o::OnlineStat{T}, f::Function, r::Int = 1_000)
     replicates = OnlineStat{T}[copy(o) for i in 1:r]
-    cached_state = Array(Float64, r)
+    cached_state = Array{Float64}(r)
     ScalarPoissonBootstrap(replicates, cached_state, f, 0, true)
 end
 
@@ -74,7 +74,7 @@ type VectorPoissonBootstrap{S <: OnlineStat{VectorInput}} <: Bootstrap{VectorInp
 end
 function PoissonBootstrap{T <: VectorInput}(o::OnlineStat{T}, f::Function, r::Int = 1_000)
     replicates = OnlineStat{T}[copy(o) for i in 1:r]
-    cached_state = Array(Float64, length(value(o)), r)
+    cached_state = Array{Float64}(length(value(o)), r)
     VectorPoissonBootstrap(replicates, cached_state, f, 0, true)
 end
 

--- a/src/streamstats/hyperloglog.jl
+++ b/src/streamstats/hyperloglog.jl
@@ -36,7 +36,7 @@ for yi in y
 end
 ```
 """
-type HyperLogLog <: OnlineStat
+type HyperLogLog{I <: Input} <: OnlineStat{I}
     m::UInt32
     M::Vector{UInt32}
     mask::UInt32
@@ -62,7 +62,7 @@ function HyperLogLog(b::Integer)
 
     altmask = ~mask
 
-    return HyperLogLog(m, M, mask, altmask, 0)
+    return HyperLogLog{Input}(m, M, mask, altmask, 0)
 end
 
 function Base.show(io::IO, counter::HyperLogLog)

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -120,7 +120,7 @@ function _fit!(o::Variances, y::AVec, γ::Float64)
     end
 end
 Base.var(o::Variances) = value(o)
-Base.std(o::Variances) = sqrt(value(o))
+Base.std(o::Variances) = sqrt.(value(o))
 Base.mean(o::Variances) = o.μ
 value(o::Variances) = nobs(o) < 2 ? zeros(o.value) : o.value * unbias(o)
 center{T<:Real}(o::Variances, x::AVec{T}) = x - mean(o)
@@ -191,10 +191,10 @@ end
 Base.mean(o::CovMatrix) = o.b
 Base.cov(o::CovMatrix) = value(o)
 Base.var(o::CovMatrix) = diag(value(o))
-Base.std(o::CovMatrix) = sqrt(var(o))
+Base.std(o::CovMatrix) = sqrt.(var(o))
 function Base.cor(o::CovMatrix)
     copy!(o.cormat, value(o))
-    v = 1.0 ./ sqrt(diag(o.cormat))
+    v = 1.0 ./ sqrt.(diag(o.cormat))
     scale!(o.cormat, v)
     scale!(v, o.cormat)
     o.cormat
@@ -447,7 +447,7 @@ function _fit!(o::Moments, y::Real, γ::Float64)
 end
 Base.mean(o::Moments) = value(o)[1]
 Base.var(o::Moments) = (value(o)[2] - value(o)[1] ^ 2) * unbias(o)
-Base.std(o::Moments) = sqrt(var(o))
+Base.std(o::Moments) = sqrt.(var(o))
 function StatsBase.skewness(o::Moments)
     v = value(o)
     (v[3] - 3.0 * v[1] * var(o) - v[1] ^ 3) / var(o) ^ 1.5


### PR DESCRIPTION
Hello. to follow the changes on Julia 0.6,
- fix the invalid subtyping error by `HyperLogLog`
- update deprecated functions `sqrt.`, `sum(abs2, itr)`, `Array{T}(m)`

thanks.