### PR TITLE
Fix printing of big MVs

### DIFF
--- a/src/vectorinput/mv.jl
+++ b/src/vectorinput/mv.jl
@@ -19,11 +19,14 @@ MV(p::Integer, o::OnlineStat{0}) = MV([copy(o) for i in 1:p])
 function Base.show{T}(io::IO, o::MV{T})
     s = name(o, true) * "("
     n = length(o.stats)
-    for i in 1:n
+    for i in 1:min(10,n)
         s *= "$(value(o.stats[i]))"
-        if i != n
+        if i != min(10,n)
             s *= ", "
         end
+    end
+    if n>10
+        s *= ", ..."
     end
     s *= ")"
     print(io, s)


### PR DESCRIPTION
Fixes #85 
Now looks:
```
julia> Series(OnlineStats.EqualWeight(), MV(n, Mean()), MV(n, Variance()), MV(n, Extrema()), MV(n, QuantileSGD([0.1,0.25,0.5,0.75,0.9])) )            
▦ Series{1,Tuple{MV{Mean},MV{Variance},MV{Extrema},MV{QuantileSGD}},EqualWeight}                                                                      
┣━━ EqualWeight(nobs = 0)                                                                                                                             
┗━━ Tracking                                                                                                                                          
    ┣━━ MV{Mean}(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ...)                                                                               
    ┣━━ MV{Variance}(-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, ...)                                                                 
    ┣━━ MV{Extrema}((Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), (Inf, -Inf), ...)                                                                                                                                                   
    ┗━━ MV{QuantileSGD}([0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0], ...)
```
For sure could be improved, but it works fine for my purposes.