### PR TITLE
Histograms with general fixed-width bins

### DIFF
--- a/src/stats/histograms.jl
+++ b/src/stats/histograms.jl
@@ -73,23 +73,23 @@ function Base.quantile(o::Hist, p = [0, .25, .5, .75, 1])
 end
 
 #-----------------------------------------------------------------------# FixedBins
-mutable struct FixedBins{E<:AbstractVector,closed} <: HistAlg{0}
+mutable struct FixedBins{closed,E<:AbstractVector} <: HistAlg{0}
     edges::E
     counts::Vector{Int}
     out::Int
 
-    function FixedBins{E,closed}(edges::E, counts::Vector{Int},
+    function FixedBins{closed,E}(edges::E, counts::Vector{Int},
                                  out::Int) where {E<:AbstractVector,closed}
         closed == :left || closed == :right ||
             error("closed must be left or right")
         length(edges) == length(counts) + 1 ||
             error("Histogram edge vectors must be 1 longer than corresponding count vectors")
         issorted(edges) || error("Histogram edge vectors must be sorted in ascending order")
-        new{E,closed}(edges, counts, out)
+        new{closed,E}(edges, counts, out)
     end
 end
 Base.@pure FixedBins(edges::AbstractVector, counts::Vector{Int}, out::Int; closed::Symbol = :left) =
-    FixedBins{typeof(edges),closed}(edges, counts, out)
+    FixedBins{closed,typeof(edges)}(edges, counts, out)
 
 get_hist_alg(e::AbstractVector; kwargs...) = FixedBins(e, zeros(Int, length(e) - 1), 0; kwargs...)
 _midpoints(o::FixedBins) = _midpoints(o.edges)
@@ -104,7 +104,7 @@ function fit!(o::FixedBins, y, γ::Number)
     end
 end
 
-function _binindex(o::FixedBins{<:AbstractVector,:left}, y)
+function _binindex(o::FixedBins{:left}, y)
     edges = o.edges
     a = first(edges)
     if y < a
@@ -122,7 +122,7 @@ function _binindex(o::FixedBins{<:AbstractVector,:left}, y)
     end
 end
 
-function _binindex(o::FixedBins{<:AbstractVector,:right}, y)
+function _binindex(o::FixedBins{:right}, y)
     edges = o.edges
     a = first(edges)
     if y < a

--- a/src/stats/histograms.jl
+++ b/src/stats/histograms.jl
@@ -12,8 +12,7 @@ get_hist_alg(o::HistAlg) = o
 # fit!
 # merge!
 
-_midpoints(e::Range) = e[1:length(e) - 1] + 0.5 * step(e)
-_midpoints(e::AbstractVector) = [(e[i+1] - e[i]) / 2 for i in 1:length(e) - 1]
+_midpoints(e::AbstractVector) = midpoints(e)
 
 #-----------------------------------------------------------------------# Hist
 """

--- a/src/visualizations/recipes.jl
+++ b/src/visualizations/recipes.jl
@@ -81,7 +81,8 @@ end
 #-----------------------------------------------------------------------# Hist 
 @recipe f(o::Hist) = o.alg
 
-@recipe f(o::FixedBins) = Histogram(o.edges, o.counts, :left)
+@recipe f(o::FixedBins{closed}) where {closed} =
+    Histogram(o.edges, o.counts, closed)
 
 @recipe function f(o::AdaptiveBins)
     linewidth --> 2

--- a/src/visualizations/recipes.jl
+++ b/src/visualizations/recipes.jl
@@ -81,7 +81,7 @@ end
 #-----------------------------------------------------------------------# Hist 
 @recipe f(o::Hist) = o.alg
 
-@recipe f(o::FixedRangeBins) = Histogram(o.edges, o.counts, :left)
+@recipe f(o::FixedBins) = Histogram(o.edges, o.counts, :left)
 
 @recipe function f(o::AdaptiveBins)
     linewidth --> 2

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -153,8 +153,13 @@ end
 #-----------------------------------------------------------------------# Hist 
 @testset "Hist" begin
     dpdf = OnlineStats._pdf
-    #### KnownBins
-    test_exact(Hist(-5:5), y, o -> value(o)[2], y -> fit(Histogram, y, -5:5, closed=:left).weights)
+    #### FixedBins
+    for edges in (-5:5, collect(-5:5)), data in (y, -6:0.75:6)
+        test_exact(Hist(edges), data, o -> value(o)[2],
+                   y -> fit(Histogram, y, -5:5, closed = :left).weights)
+        test_exact(Hist(edges; closed = :right), data, o -> value(o)[2],
+                   y -> fit(Histogram, y, -5:5, closed = :right).weights)
+    end
     test_exact(Hist(-5:.1:5), y, extrema, extrema, (a,b)->≈(a,b;atol=.2))
     test_exact(Hist(-5:.1:5), y, mean, mean, (a,b)->≈(a,b;atol=.2))
     test_exact(Hist(-5:.1:5), y, nobs, length)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -154,11 +154,13 @@ end
 @testset "Hist" begin
     dpdf = OnlineStats._pdf
     #### FixedBins
-    for edges in (-5:5, collect(-5:5)), data in (y, -6:0.75:6)
-        test_exact(Hist(edges), data, o -> value(o)[2],
-                   y -> fit(Histogram, y, -5:5, closed = :left).weights)
-        test_exact(Hist(edges; closed = :right), data, o -> value(o)[2],
-                   y -> fit(Histogram, y, -5:5, closed = :right).weights)
+    for edges in (-5:5, collect(-5:5), [-5, -3.5, 0, 1, 4, 5.5])
+        for data in (y, -6:0.75:6)
+            test_exact(Hist(edges), data, o -> value(o)[2],
+                       y -> fit(Histogram, y, edges, closed = :left).weights)
+            test_exact(Hist(edges; closed = :right), data, o -> value(o)[2],
+                       y -> fit(Histogram, y, edges, closed = :right).weights)
+        end
     end
     test_exact(Hist(-5:.1:5), y, extrema, extrema, (a,b)->≈(a,b;atol=.2))
     test_exact(Hist(-5:.1:5), y, mean, mean, (a,b)->≈(a,b;atol=.2))


### PR DESCRIPTION
Hi,

while playing around with OnlineStats, I noticed that I would like to create histograms with non-uniform bins of fixed width and hence be able to specify general `AbstractVector`s as edge vectors of fixed-width bins. I'm not sure whether it is of general interest, but this PR resolves that issue by slightly changing the current implementation. Moreover, similar to the code in StatsBase.jl, I added an option for switching between left-closed and right-closed bins (only for histograms with fixed-width bins).