### PR TITLE
Allow CovMatrix to fit any data of type Number, not just Float64

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,7 +14,7 @@ end
 
 function smooth_syr!(A::AbstractMatrix, x, γ::Number)
     for j in 1:size(A, 2), i in 1:j
-        A[i, j] = smooth(A[i,j], x[i] * x[j], γ)
+        A[i, j] = smooth(A[i,j], x[i] * conj(x[j]), γ)
     end
 end
 
@@ -34,7 +34,7 @@ Statistics.std(o::OnlineStat; kw...) = sqrt.(var(o; kw...))
 
 const ϵ = 1e-7
 
-#-----------------------------------------------------------------------# BiasVec 
+#-----------------------------------------------------------------------# BiasVec
 """
     BiasVec(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,9 @@ const y = randn(1000)
 const y2 = randn(1000)
 const x = randn(1000, 5)
 const x2 = randn(1000, 5)
-
-#-----------------------------------------------------------------------# Custom Printing 
+const z = Complex.(randn(1000, 5), randn(1000, 5))
+const z2 = Complex.(randn(1000, 5), randn(1000, 5))
+#-----------------------------------------------------------------------# Custom Printing
 @info("Custom Printing")
 for stat in [
         BiasVec([1,2,3])
@@ -34,7 +35,7 @@ for stat in [
 end
 
 # TODO: uncomment when Plots release for 0.7 is available
-# #-----------------------------------------------------------------------# Plots 
+# #-----------------------------------------------------------------------# Plots
 # println("\n\n")
 # @info("Sanity checking Plots")
 # plot(Mean())
@@ -89,10 +90,10 @@ nrows(t::Tuple) = length(t[2])
 nrows(y::Base.Iterators.Zip2) = length(y)
 
 
-#-----------------------------------------------------------------------# utils 
+#-----------------------------------------------------------------------# utils
 println("\n\n")
 @info("Testing Utils")
-@testset "utils" begin 
+@testset "utils" begin
     @test O._dot((1,2,3), (4,5,6)) == sum([1,2,3] .* [4,5,6])
     @test length(BiasVec((1,2,3))) == 4
     @test size(BiasVec([1,2,3])) == (4,)
@@ -103,13 +104,13 @@ end
 println("\n\n")
 @info("Testing Stats")
 #-----------------------------------------------------------------------# AutoCov
-@testset "AutoCov" begin 
+@testset "AutoCov" begin
     test_exact(AutoCov(10), y, autocov, autocov(y, 0:10))
     test_exact(AutoCov(10), y, autocor, autocor(y, 0:10))
     test_exact(AutoCov(10), y, nobs, length)
 end
-#-----------------------------------------------------------------------# Bootstrap 
-@testset "Bootstrap" begin 
+#-----------------------------------------------------------------------# Bootstrap
+@testset "Bootstrap" begin
     o = fit!(Bootstrap(Mean(), 100, [1]), y)
     @test all(value.(o.replicates) .== value(o.stat))
     @test length(confint(o)) == 2
@@ -119,8 +120,8 @@ end
     test_merge(CallFun(Mean(), x->nothing), y, y2)
     test_exact(CallFun(Mean(), x->nothing), y, value, mean)
 end
-# #-----------------------------------------------------------------------# Count 
-# @testset "Count" begin 
+# #-----------------------------------------------------------------------# Count
+# @testset "Count" begin
 #     test_exact(Count(), y, value, length)
 #     test_merge(Count(), y, y2, ==)
 # end
@@ -140,7 +141,8 @@ end
     @test probs(o, 7:9) == zeros(3)
 end
 #-----------------------------------------------------------------------# CovMatrix
-@testset "CovMatrix" begin 
+@testset "CovMatrix" begin
+    test_exact(CovMatrix(Float64, 5), x, var, x -> var(x, dims=1))
     test_exact(CovMatrix(5), x, var, x -> var(x, dims=1))
     test_exact(CovMatrix(), x, std, x -> std(x, dims=1))
     test_exact(CovMatrix(5), x, mean, x -> mean(x, dims=1))
@@ -148,10 +150,19 @@ end
     test_exact(CovMatrix(5), x, cov, cov)
     test_exact(CovMatrix(), x, o->cov(o; corrected=false), cov(x, dims=1, corrected=false))
     test_merge(CovMatrix(), x, x2)
+    # Complex values
+    test_exact(CovMatrix(Complex{Float64}, 5), z, var, z -> var(z, dims=1))
+    test_exact(CovMatrix(Complex{Float64}, 5), z, var, z -> var(z, dims=1))
+    test_exact(CovMatrix(Complex{Float64}), z, std, z -> std(z, dims=1))
+    test_exact(CovMatrix(Complex{Float64}, 5), z, mean, z -> mean(z, dims=1))
+    test_exact(CovMatrix(Complex{Float64}), z, cor, cor)
+    test_exact(CovMatrix(Complex{Float64}, 5), z, cov, cov)
+    test_exact(CovMatrix(Complex{Float64}), z, o->cov(o; corrected=false), cov(z, dims=1, corrected=false))
+    test_merge(CovMatrix(Complex{Float64}), z, z2)
 end
-#-----------------------------------------------------------------------# CStat 
-@testset "CStat" begin 
-    data = y + y2 * im 
+#-----------------------------------------------------------------------# CStat
+@testset "CStat" begin
+    data = y + y2 * im
     data2 = y2 + y * im
     test_exact(CStat(Mean()), data, o->value(o)[1], mean(y))
     test_exact(CStat(Mean()), data, o->value(o)[2], mean(y2))
@@ -159,15 +170,15 @@ end
     test_merge(CStat(Mean()), y, y2)
     test_merge(CStat(Mean()), data, data2)
 end
-#-----------------------------------------------------------------------# Diff 
-@testset "Diff" begin 
+#-----------------------------------------------------------------------# Diff
+@testset "Diff" begin
     test_exact(Diff(), y, value, y -> y[end] - y[end-1])
     o = fit!(Diff(Int), 1:10)
     @test diff(o) == 1
     @test last(o) == 10
 end
 #-----------------------------------------------------------------------# Extrema
-@testset "Extrema" begin 
+@testset "Extrema" begin
     test_exact(Extrema(), y, extrema, extrema, ==)
     test_exact(Extrema(), y, maximum, maximum, ==)
     test_exact(Extrema(), y, minimum, minimum, ==)
@@ -175,7 +186,7 @@ end
     test_merge(Extrema(), y, y2, ==)
 end
 #-----------------------------------------------------------------------# FastNode
-@testset "FastNode" begin 
+@testset "FastNode" begin
     data = (x,rand(1:3,1000))
     data2 = (x,rand(1:3,1000))
     Y = vcat(data, data2)
@@ -195,13 +206,13 @@ end
     test_exact(FastNode(5, 3), data, O.nvars, 5)
     @test classify(o) ∈ [1, 2, 3]
 end
-#-----------------------------------------------------------------------# FastTree 
-@testset "FastTree" begin 
+#-----------------------------------------------------------------------# FastTree
+@testset "FastTree" begin
     X, Y = O.fakedata(FastNode, 10^4, 10)
     o = fit!(FastTree(10; splitsize=100), (X,Y))
     @test classify(o, X[1,:]) ∈ [1, 2]
     @test all(0 .< classify(o, X) .< 3)
-    @test O.nkeys(o) == 2 
+    @test O.nkeys(o) == 2
     @test O.nvars(o) == 10
     @test mean(classify(o, X) .== Y) > .5
     test_exact(FastTree(10), (X[1,:],Y[1]), length, 1)
@@ -211,33 +222,33 @@ end
     X,Y = OnlineStats.fakedata(FastNode, 10^4, 1)
     fit!(FastTree(1, splitsize=100),(X,Y))
 end
-#-----------------------------------------------------------------------# FastForest 
-@testset "FastForest" begin 
+#-----------------------------------------------------------------------# FastForest
+@testset "FastForest" begin
     X, Y = O.fakedata(FastNode, 10^4, 10)
     o = fit!(FastForest(10; splitsize=500, λ = .7), (X, Y))
     @test classify(o, randn(10)) in 1:2
     @test mean(classify(o, X) .== Y) > .5
 end
 #-----------------------------------------------------------------------# Fit[Dist]
-@testset "Fit[Dist]" begin 
-@testset "FitBeta" begin 
+@testset "Fit[Dist]" begin
+@testset "FitBeta" begin
     test_merge(FitBeta(), rand(10), rand(10))
     @test value(FitBeta()) == (1.0, 1.0)
 end
-@testset "FitCauchy" begin 
+@testset "FitCauchy" begin
     test_exact(FitCauchy(), y, value, y->(0,1), atol = .5)
     test_merge(FitCauchy(), y, y2, atol = .5)
     @test value(FitCauchy()) == (0.0, 1.0)
-end 
-@testset "FitGamma" begin 
+end
+@testset "FitGamma" begin
     test_merge(FitGamma(), y, y2)
     @test value(FitGamma()) == (1.0, 1.0)
 end
-@testset "FitLogNormal" begin 
+@testset "FitLogNormal" begin
     test_merge(FitLogNormal(), exp.(y), exp.(y2))
     @test value(FitLogNormal()) == (0.0, 1.0)
 end
-@testset "FitNormal" begin 
+@testset "FitNormal" begin
     test_merge(FitNormal(), y, y2)
     test_exact(FitNormal(), y, value, (mean(y), std(y)))
     test_exact(FitNormal(), y, mean, mean(y))
@@ -251,29 +262,29 @@ end
     @test O.cdf(o, 0.0) ≈ 0.5
     @test ≈(O.cdf(o, -1.0), 0.15865525393145702; atol=.001)
 end
-@testset "FitMultinomial" begin 
+@testset "FitMultinomial" begin
     o = FitMultinomial(5)
     @test value(o)[2] == ones(5) / 5
     data = [1 2 3 4 5; 1 2 3 4 5]
     test_exact(o, data, o->value(o)[2], collect(2:2:10) ./ sum(data))
     test_merge(FitMultinomial(3), rand(1:4, 10, 3), rand(2:7, 11, 3))
 end
-@testset "FitMvNormal" begin 
+@testset "FitMvNormal" begin
     test_merge(FitMvNormal(2), [y y2], [y2 y])
     @test value(FitMvNormal(2)) == (zeros(2), Matrix(I, 2, 2))
 end
 end
-#-----------------------------------------------------------------------# FTSeries 
-@testset "FTSeries" begin 
+#-----------------------------------------------------------------------# FTSeries
+@testset "FTSeries" begin
     test_merge(FTSeries(Mean(), Variance(); transform = abs), y, y2)
     test_exact(FTSeries(Mean(); transform=abs), y, o->value(o)[1], mean(abs, y))
     data = [-1, 1, 2]
     o = fit!(FTSeries(Mean(); filter = x->x>0), data)
-    @test o.nfiltered == 1 
+    @test o.nfiltered == 1
     @test nobs(o) == 2
 end
-#-----------------------------------------------------------------------# Group 
-@testset "Group" begin 
+#-----------------------------------------------------------------------# Group
+@testset "Group" begin
     o = Group(Mean(), Mean(), Mean(), Variance(), Variance())
     @test o[1] == first(o) == Mean()
     @test o[5] == last(o) == Variance()
@@ -289,19 +300,19 @@ end
 
     g = fit!(5Mean(), x)
     @test length(g) == 5
-    for (i, oi) in enumerate(g) 
+    for (i, oi) in enumerate(g)
         @test value(oi) ≈ mean(x[:, i])
     end
 end
-#-----------------------------------------------------------------------# Group 
-@testset "GroupBy" begin 
+#-----------------------------------------------------------------------# Group
+@testset "GroupBy" begin
     o = GroupBy{Int}(Mean())
     fit!(o, zip([1,1,2,2], 1:4))
     @test value(value(o)[1]) ≈ 1.5
     @test value(value(o)[2]) ≈ 3.5
 end
-#-----------------------------------------------------------------------# Hist 
-@testset "Hist" begin 
+#-----------------------------------------------------------------------# Hist
+@testset "Hist" begin
 @testset "FixedBins" begin
     test_merge(Hist(-5:.1:5), y, y2)
     for edges in (-5:5, collect(-5:5), [-5, -3.5, 0, 1, 4, 5.5])
@@ -318,17 +329,17 @@ end
     test_exact(Hist(-5:.1:5), y, nobs, length)
     test_exact(Hist(-5:.1:5), y, var, var, atol=.2)
     test_merge(Hist(-5:.1:5), y, y2)
-    # merge unequal bins 
+    # merge unequal bins
     r1, r2 = -5:.2:5, -5:.1:5
     @test merge!(fit!(Hist(r1), y), fit!(Hist(r2), y2)) == fit!(Hist(r1), vcat(y, y2))
     @test O.pdf(fit!(Hist(-5:.1:5), y), 0) > 0
     @test O.pdf(fit!(Hist(-5:.1:5), y), 100) == 0
-end 
-@testset "FixedBins2" begin 
+end
+@testset "FixedBins2" begin
     test_exact(Hist(-5:.1:5, -5:.1:5), zip(y, y2), nobs, length(y))
     test_exact(Hist(-5:5,-5:5), zip([1,10, 10], [10, 1, 10]), x->x.alg.out, 3)
 end
-@testset "AdaptiveBins" begin 
+@testset "AdaptiveBins" begin
     test_exact(Hist(1000), y, mean, mean)
     test_exact(Hist(1000), y, nobs, length)
     test_exact(Hist(1000), y, var, var)
@@ -342,7 +353,7 @@ end
     # test_merge(Hist(Float32, 2000), Float32.(y), Float32.(y2))
 
     data = randn(10_000)
-    
+
     test_exact(Hist(100), data, o->O.pdf(o, -10), 0.0)
     test_exact(Hist(100), data, o->O.pdf(o,0), 0.3989422804014327, atol=.2)
     test_exact(Hist(100), data, o->O.pdf(o, 10), 0.0)
@@ -354,34 +365,34 @@ end
     @test Hist(10) == Hist(10)
 end
 end
-#-----------------------------------------------------------------------# HyperLogLog 
-@testset "HyperLogLog" begin 
+#-----------------------------------------------------------------------# HyperLogLog
+@testset "HyperLogLog" begin
     test_exact(HyperLogLog(12), y, value, y->length(unique(y)), atol=50)
     test_merge(HyperLogLog(4), y, y2)
 end
-#-----------------------------------------------------------------------# IndexedPartition 
-@testset "IndexedPartition" begin 
+#-----------------------------------------------------------------------# IndexedPartition
+@testset "IndexedPartition" begin
     o = IndexedPartition(Float64, Mean())
     fit!(o, [y y2])
 end
 #-----------------------------------------------------------------------# KMeans
-@testset "KMeans" begin 
+@testset "KMeans" begin
     o = fit!(KMeans(5,2), x)
 end
 #-----------------------------------------------------------------------# LinReg
-@testset "LinReg" begin 
+@testset "LinReg" begin
     test_exact(LinReg(), (x,y), value, x\y)
     test_merge(LinReg(), (x,y), (x2,y2))
-    # ridge 
+    # ridge
     o = fit!(LinReg(), (x,y))
     @test coef(o) ≈ x \ y
     @test coef(o, .1) ≈ (x'x + 100 * I) \ x'y
     λ = rand(5)
     @test coef(o, λ) ≈ (x'x + 1000 * Diagonal(λ)) \ x'y
-    @test predict(o, x) == x * o.β 
+    @test predict(o, x) == x * o.β
     @test predict(o, x[1,:]) == dot(o.β, x[1, :])
 end
-@testset "LinRegBuilder" begin 
+@testset "LinRegBuilder" begin
     test_merge(LinRegBuilder(), [x y], [x2 y2])
     test_exact(LinRegBuilder(), [x y], o->coef(o,y=6), [x ones(length(y))] \ y)
     o = fit!(LinRegBuilder(), [y x])
@@ -389,19 +400,19 @@ end
     λ = rand(5)
     @test coef(o, λ; bias=false) ≈ (x'x + 1000 * Diagonal(λ)) \ x'y
 end
-#-----------------------------------------------------------------------# Mean 
-@testset "Mean" begin 
+#-----------------------------------------------------------------------# Mean
+@testset "Mean" begin
     test_exact(Mean(), y, mean, mean)
     test_merge(Mean(), y, y2)
 end
-#-----------------------------------------------------------------------# ML 
-@testset "ML" begin 
+#-----------------------------------------------------------------------# ML
+@testset "ML" begin
     o = OnlineStats.preprocess(eachrow(x))
-    for i in 1:5 
+    for i in 1:5
         @test o.group[i] isa OnlineStats.Numerical
     end
     o = OnlineStats.preprocess(eachrow(rand(Bool, 100, 2)))
-    for i in 1:2 
+    for i in 1:2
         @test o.group[i] isa OnlineStats.Categorical
     end
     o = OnlineStats.preprocess(eachrow(rand(1:5, 100, 5)), 3=>OnlineStats.Categorical(Int))
@@ -409,7 +420,7 @@ end
     @test o.group[1] isa OnlineStats.Numerical
 end
 #-----------------------------------------------------------------------# Moments
-@testset "Moments" begin 
+@testset "Moments" begin
     test_exact(Moments(), y, value, [mean(y), mean(y .^ 2), mean(y .^ 3), mean(y .^4) ])
     test_exact(Moments(), y, skewness, skewness, atol = .1)
     test_exact(Moments(), y, kurtosis, kurtosis, atol = .1)
@@ -418,12 +429,12 @@ end
     test_exact(Moments(), y, std, std)
     test_merge(Moments(), y, y2)
 end
-#-----------------------------------------------------------------------# Mosaic 
-@testset "Mosaic" begin 
+#-----------------------------------------------------------------------# Mosaic
+@testset "Mosaic" begin
     test_merge(Mosaic(Int,Int), rand(1:5, 100, 2), rand(1:5, 100, 2), ==)
 end
 #-----------------------------------------------------------------------# MovingTimeWindow
-@testset "MovingTimeWindow" begin 
+@testset "MovingTimeWindow" begin
     dates = Date(2010):Day(1):Date(2011)
     data = 1:length(dates)
     o = MovingTimeWindow(Day(4); timetype=Date, valtype=Int)
@@ -431,14 +442,14 @@ end
     test_merge(o, zip(dates[1:2], data[1:2]), zip(dates[3:4], data[3:4]), ==)
 end
 #-----------------------------------------------------------------------# MovingWindow
-@testset "MovingWindow" begin 
+@testset "MovingWindow" begin
     test_exact(MovingWindow(10,Int), 1:12, value, 3:12)
-    for i in 1:10 
+    for i in 1:10
         test_exact(MovingWindow(10,Int), 1:12, o -> o[i], i + 2)
     end
 end
 #-----------------------------------------------------------------------# NBClassifier
-@testset "NBClassifier" begin 
+@testset "NBClassifier" begin
     X, Y = randn(1000, 5), rand(Bool, 1000)
     X2, Y2 = randn(1000, 5), rand(Bool, 1000)
     o = fit!(NBClassifier(5, Bool), (X,Y))
@@ -452,13 +463,13 @@ end
     @test length(o[2]) == 2
 end
 #-----------------------------------------------------------------------# OrderStats
-@testset "OrderStats" begin 
+@testset "OrderStats" begin
     test_merge(OrderStats(100), y, y2)
     test_exact(OrderStats(1000), y, value, sort, ==)
     test_exact(OrderStats(1000), y, quantile, quantile)
 end
-#-----------------------------------------------------------------------# Partition 
-@testset "Partition" begin 
+#-----------------------------------------------------------------------# Partition
+@testset "Partition" begin
     test_exact(Partition(Mean()), y, nobs, length)
     # merging
     o = fit!(Partition(Mean(), 1000), y)
@@ -471,10 +482,10 @@ end
         @test value(o.parts[i]) ≈ value(o2.parts[500 + i])
     end
 end
-#-----------------------------------------------------------------------# ProbMap 
-@testset "ProbMap" begin 
+#-----------------------------------------------------------------------# ProbMap
+@testset "ProbMap" begin
     test_exact(ProbMap(Float64), y, o->sort(collect(keys(o.value))), sort(y))
-    # merge 
+    # merge
     data, data2 = rand(1:4, 100), rand(1:4, 100)
     o = fit!(ProbMap(Int), data)
     o2 = fit!(ProbMap(Int), data2)
@@ -485,13 +496,13 @@ end
     test_exact(ProbMap(Int), [1,1,2,2,3,3,4,4], o->probs(o, [1,2, 9]), [.5, .5, 0])
 end
 #-----------------------------------------------------------------------# Quantile
-@testset "Quantile/P2Quantile" begin 
+@testset "Quantile/P2Quantile" begin
     data = randn(10_000)
     data2 = randn(10_000)
     τ = .1:.1:.9
     for o in [
-            Quantile(τ; alg=SGD()), 
-            Quantile(τ; alg=MSPI()), 
+            Quantile(τ; alg=SGD()),
+            Quantile(τ; alg=MSPI()),
             Quantile(τ; alg=OMAS()),
             Quantile(τ; alg=ADAGRAD())
             ]
@@ -503,7 +514,7 @@ end
     end
 end
 #-----------------------------------------------------------------------# ReservoirSample
-@testset "ReservoirSample" begin 
+@testset "ReservoirSample" begin
     test_exact(ReservoirSample(1000), y, value, identity, ==)
     # merge
     o1 = fit!(ReservoirSample(9), y)
@@ -514,22 +525,22 @@ end
         @test (yi ∈ y) || (yi ∈ y2)
     end
 end
-#-----------------------------------------------------------------------# Series 
-@testset "Series" begin 
+#-----------------------------------------------------------------------# Series
+@testset "Series" begin
     test_merge(Series(Mean(), Variance()), y, y2)
     test_exact(Series(Mean(), Variance()), y, o->value(o)[1], mean(y))
     test_exact(Series(Mean(), Variance()), y, o->value(o)[2], var(y))
 end
-#-----------------------------------------------------------------------# StatHistory 
-@testset "StatHistory" begin 
+#-----------------------------------------------------------------------# StatHistory
+@testset "StatHistory" begin
     o = fit!(StatHistory(Mean(), 10), 1:20)
     @test length(o.circbuff) == 10
     for (i, m) in enumerate(reverse(o.circbuff))
         @test nobs(m) == 10 + i
     end
 end
-#-----------------------------------------------------------------------# StatLearn 
-@testset "StatLearn" begin 
+#-----------------------------------------------------------------------# StatLearn
+@testset "StatLearn" begin
     X = randn(10_000, 5)
     β = collect(-1:.5:1)
     Y = X * β + randn(10_000)
@@ -558,22 +569,22 @@ end
         println()
     end
 end
-#-----------------------------------------------------------------------# Sum 
-@testset "Sum" begin 
+#-----------------------------------------------------------------------# Sum
+@testset "Sum" begin
     test_exact(Sum(), y, sum, sum)
     test_exact(Sum(Int), 1:100, sum, sum)
     test_merge(Sum(), y, y2)
 end
-#-----------------------------------------------------------------------# Variance 
-@testset "Variance" begin 
+#-----------------------------------------------------------------------# Variance
+@testset "Variance" begin
     test_exact(Variance(), y, mean, mean)
     test_exact(Variance(), y, std, std)
     test_exact(Variance(), y, var, var)
     test_merge(Variance(), y, y2)
 
     # Issue 116
-    @test std(Variance()) == 1 
-    @test std(fit!(Variance(), 1)) == 1 
+    @test std(Variance()) == 1
+    @test std(fit!(Variance(), 1)) == 1
     @test std(fit!(Variance(), [1, 2])) == sqrt(.5)
 end
 


### PR DESCRIPTION
Changes to type parameterization and methods, includes tests.
My editor also automatically deleted a bunch of trailing whitespaces...the number of changed lines is not actually that many.

The way I did it, `CovMatrix()` still defaults to `Float64`, and if the user tries to fit it to data of some other type it [throws an error,](https://github.com/ElOceanografo/OnlineStats.jl/blob/ca958ed81f1dfd22e12360c62a7db819e54ded38/src/stats/stats.jl#L285) suggesting they construct the `CovMatrix` explicitly with the type they need.  Alternatively there could be automatic promotion...not sure what you think would be better?