### PR TITLE
Add midpoint method for TimeType

### DIFF
--- a/src/viz/partition.jl
+++ b/src/viz/partition.jl
@@ -36,6 +36,8 @@ function midpoint(o::Part)
     end
 end
 
+midpoint(o::Part{<:TimeType}) = o.a + fld(o.b - o.a, 2)
+
 width(o::Part) = o.b - o.a
 
 isfull(o::Part{Int}) = (nobs(o) == o.b - o.a + 1)


### PR DESCRIPTION
Fixes plotting of `IndexedPartition` with `Date` or `DateTime` index.
```julia
using Dates
x = Date(2010):Day(1):Date(2011)
y = rand(1:10, length(x))
o = fit!(IndexedPartition(Date, CountMap(Int)), zip(x, y))
plot(o)
```