### PR TITLE
Fixed docs examples to explicitly iterate over observation rows

### DIFF
--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -185,7 +185,7 @@ Online parameter estimate of a `d`-dimensional MvNormal distribution (MLE).
 # Example 
 
     y = randn(100, 2)
-    o = fit!(FitMvNormal(2), y)
+    o = fit!(FitMvNormal(2), eachrow(y))
 """
 struct FitMvNormal <: OnlineStat{VectorOb}
     cov::CovMatrix{Float64}

--- a/src/stats/fasttree.jl
+++ b/src/stats/fasttree.jl
@@ -116,7 +116,7 @@ Each variable is summarized by `stat`, which can be `FitNormal()` or `Hist(nbins
     x = randn(10^5, 10)
     y = rand([1,2], 10^5)
 
-    o = fit!(FastTree(10), (x,y))
+    o = fit!(FastTree(10), zip(eachrow(x),y))
 
     xi = randn(10)
     classify(o, xi)
@@ -183,7 +183,7 @@ Calculate a random forest where each variable is summarized by `stat`.
 
     x, y = randn(10^5, 10), rand(1:2, 10^5)
 
-    o = fit!(FastForest(10), (x,y))
+    o = fit!(FastForest(10), zip(eachrow(x),y))
 
     classify(o, x[1,:])
 """

--- a/src/stats/linreg.jl
+++ b/src/stats/linreg.jl
@@ -8,7 +8,7 @@ Linear regression, optionally with element-wise ridge regularization.
 
     x = randn(100, 5)
     y = x * (1:5) + randn(100)
-    o = fit!(LinReg(), (x,y))
+    o = fit!(LinReg(), zip(eachrow(x),y))
     coef(o)
     coef(o, .1)
     coef(o, [0,0,0,0,Inf])
@@ -73,7 +73,7 @@ parameter `λ`.  An intercept (`bias`) term is added by default.
 # Examples
 
     x = randn(1000, 10)
-    o = fit!(LinRegBuilder(), x)
+    o = fit!(LinRegBuilder(), eachrow(x))
 
     coef(o; y=3, verbose=true)
 

--- a/src/stats/nbclassifier.jl
+++ b/src/stats/nbclassifier.jl
@@ -9,7 +9,7 @@ class `K`, predictor variables are summarized by the `stat`.
 
     x, y = randn(10^4, 10), rand(Bool, 10^4)
 
-    o = fit!(NBClassifier(10, Bool), (x,y))
+    o = fit!(NBClassifier(10, Bool), zip(eachrow(x),y))
     collect(keys(o))
     probs(o)
 

--- a/src/stats/statlearn.jl
+++ b/src/stats/statlearn.jl
@@ -22,7 +22,7 @@ nonnegative regularization parameters, and ``g`` is a penalty function.
     x = randn(1000, 5)
     y = x * range(-1, stop=1, length=5) + randn(1000)
 
-    o = fit!(StatLearn(5, MSPI()), (x, y))
+    o = fit!(StatLearn(5, MSPI()), zip(eachrow(x), y))
     coef(o)
 """
 mutable struct StatLearn{A<:Algorithm, L<:Loss, P<:Penalty, W} <: OnlineStat{XY}

--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -313,7 +313,7 @@ Approximate K-Means clustering of `k` clusters and `p` variables.
 
     x = [randn() + 5i for i in rand(Bool, 10^6), j in 1:2]
 
-    o = fit!(KMeans(2, 2), x)
+    o = fit!(KMeans(2, 2), eachrow(x))
 
     sort!(o; rev=true)  # Order clusters by number of observations
 """


### PR DESCRIPTION
vim insisted on adding a newline at the end of every file.