### PR TITLE
Partition clarify docstring

### DIFF
--- a/src/viz/partition.jl
+++ b/src/viz/partition.jl
@@ -50,9 +50,9 @@ end
 
 #-----------------------------------------------------------------------# Partition 
 """
-    Partition(stat, nparts=100)
+    Partition(stat, partsize=100)
 
-Split a data stream into `nparts` where each part is summarized by `stat`.
+Split a data stream into parts of `partsize`, where each part is summarized by `stat`.
 
 # Example 
 


### PR DESCRIPTION
My initial interpretation of the old docstring was that it splits the stream into `nparts` parts, whereas of course it splits it into parts of size `nparts`. Perhaps this slight reprashing can help.