### PR TITLE
CCIPCA algorithm for online PCA

### DIFF
--- a/src/OnlineStats.jl
+++ b/src/OnlineStats.jl
@@ -46,6 +46,7 @@ export
     ReservoirSample,
     SGDStat, StatLearn, StatHistory, StatLag,
     KahanSum, KahanMean, KahanVariance,
+    CCIPCA,
 # other
     OnlineStat, BiasVec
 
@@ -63,6 +64,7 @@ include("stats/linreg.jl")
 include("stats/statlearn.jl")
 include("stats/stochasticlm.jl")
 include("stats/kahan.jl")
+include("stats/pca.jl")
 
 include("viz/partition.jl")
 include("viz/mosaicplot.jl")

--- a/src/OnlineStats.jl
+++ b/src/OnlineStats.jl
@@ -7,7 +7,7 @@ import OnlineStatsBase: value, name, _fit!, _merge!, bessel, pdf, probs, smooth,
     smooth_syr!, eachcol, eachrow, nvars, Weight, Centroid, ClosedInterval
 
 import StatsBase: fit!, nobs, autocov, autocor, confint, skewness, kurtosis, entropy, midpoints,
-    fweights, sample, coef, predict, Histogram, ecdf
+    fweights, sample, coef, predict, Histogram, ecdf, transform
 
 using OrderedCollections: OrderedDict
 using SweepOperator: sweep!
@@ -46,7 +46,7 @@ export
     ReservoirSample,
     SGDStat, StatLearn, StatHistory, StatLag,
     KahanSum, KahanMean, KahanVariance,
-    CCIPCA,
+    CCIPCA, transform,
 # other
     OnlineStat, BiasVec
 

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -1,0 +1,89 @@
+# Implements Candid Covariance-Free Incremental PCA algorithm of Weng et al:
+# Weng, Juyang, Yilu Zhang, and Wey-Shiuan Hwang. "Candid covariance-free 
+# incremental principal component analysis." IEEE Transactions on Pattern 
+# Analysis and Machine Intelligence 25.8 (2003): 1034-1040.
+#
+# A comparison of online PCA algorithms in 2018 showed it to be a good
+# trade-off in that it is fast and has low reconstruction error:
+# H. Cardot and D. Degras, "Online Principal Component Analysis in 
+# High Dimension: Which Algorithm to Choose?", Int. Statistical Review, 2018-
+
+"""
+    CCIPCA(outdim::Int, indim::Int; l::Int)
+
+Online PCA with the CCIPCA (Candid Covariance-free Incremental PCA) algorithm,
+where outdim is the number of dimension to project to, indim is the length
+of incoming vectors, and l is the level of amnesia. Give values in the range
+2-4 of l if you want old vectors to be gradually less important, i.e.
+latest vectors added get more weight.
+
+This is a very fast, simple, and online approximation of PCA. It can be used
+for Dimensionality Reduction to project high-dimensional vectors into a 
+low-dimensional (typically 2D or 3D) space. This algorithm has shown very 
+good properties in comparative studies; it is both fast and give a good 
+approximation to (batch) PCA.
+"""
+mutable struct CCIPCA <: OnlineStat{Vector{Float64}}
+    U::Matrix{Float64}      # Eigenvectors, one row per indim, one column per outdim
+    lambda::Vector{Float64} # Eigenvalues, one per outdim
+    center::Vector{Float64} # Center/mean, one per indim
+    l::Int
+    n::Int
+end
+function CCIPCA(indim::Int, outdim::Int; l::Int=0)
+    @assert outdim < indim
+    @assert l >= 0
+    center = zeros(Float64, indim)
+    lambda = zeros(Float64, outdim)
+    U      = zeros(Float64, indim, outdim)
+    CCIPCA(U, lambda, center, l, 0)
+end
+Base.length(o::CCIPCA) = outdim(o) # Number of eigen-vectors
+Base.getindex(o::CCIPCA, i) = o.U[:, i]
+Base.lastindex(o::CCIPCA) = outdim(o)
+Base.size(o::CCIPCA) = (indim(o), outdim(o))
+@inline outdim(o::CCIPCA) = length(o.lambda)
+@inline indim(o::CCIPCA) = length(o.center)
+function _fit!(o::CCIPCA, x::Vector{Float64})
+    @assert length(x) == indim(o)
+    n = o.n + 1
+    # update center with new observation:
+    o.center = (o.n * o.center .+ x)/n
+    # center the new observation, unless this is the first observation:
+    xi = (o.n > 0) ? (x .- o.center) : deepcopy(x)
+    # Now recalc eigen-values and -vectors given the new observation:
+    f = (1.0+o.l)/n
+    @inbounds for i in 1:outdim(o)
+        if i == n
+            o.lambda[i] = norm(xi)
+            o.U[:, i] = xi / o.lambda[i]
+            break
+        end
+        v = (1-f) * o.lambda[i] * o.U[:, i] + f * dot(o.U[:, i], xi) * xi
+        o.lambda[i] = norm(v)
+        o.U[:, i] = v/o.lambda[i]
+        xi = xi .- (dot(o.U[:, i], xi) * o.U[:, i])
+    end
+    o.n = n
+end
+function transform(o::CCIPCA, u::AbstractArray{Float64})
+    @assert indim(o) == length(u)
+    (u .- o.center)' * o.U
+end
+function reconstruct(o::CCIPCA, uproj::AbstractArray{Float64})
+    @assert outdim(o) == length(uproj)
+    o.center .+ (o.U * uproj')
+end
+function fittransform!(o::CCIPCA, u::Vector)
+    _fit!(o, u)
+    transform(o, u)
+end
+function eigenvalue(o::CCIPCA, i::Int)
+    @assert 1 <= i <= outdim(o) "This CCIPCA has $(outdim(o)) eigenvalues, cannot return eigenvalue $(i)!"
+    o.lambda[i]
+end
+function eigenvector(o::CCIPCA, i::Int)
+    @assert 1 <= i <= outdim(o) "This CCIPCA has $(outdim(o)) eigenvectors, cannot return eigenvector $(i)!"
+    o.U[:, i]
+end
+eigenvalues(o::CCIPCA) = o.lambda

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -145,12 +145,20 @@ end
 """
     eigenvalue(o::CCIPCA, i::Int)
 
-Get the `i`th eigenvalue of `o`.
+Get the `i`th eigenvalue of `o`. Also called principal variance
+for PCA.
 """
 function eigenvalue(o::CCIPCA, i::Int)
     @assert 1 <= i <= outdim(o) "This CCIPCA has $(outdim(o)) eigenvalues, cannot return eigenvalue $(i)!"
     o.lambda[i]
 end
+"""
+    eigenvalue(o::CCIPCA, i::Int)
+
+Get the `i`th eigenvalue of `o`. Also called principal variance
+for PCA.
+"""
+principalvar(o::CCIPCA, i::Int) = eigenvalue(o, i)
 """
     eigenvector(o::CCIPCA, i::Int)
 
@@ -161,13 +169,16 @@ function eigenvector(o::CCIPCA, i::Int)
     o.U[:, i]
 end
 eigenvalues(o::CCIPCA) = Float64[eigenvalue(o, i) for i in 1:outdim(o)]
+principalvars(o::CCIPCA) = eigenvalues(o)
 """
-    variation(o::CCIPCA)
+    relativevariances(o::CCIPCA)
 
-Get the variation (explained) in the direction of each eigenvector.
-Returns a vector of zeros if no vectors have yet been fitted.
+Get the relative variance (explained) in the direction of each 
+eigenvector. Returns a vector of zeros if no vectors have yet been fitted.
+Note that this does not inclue the residual variance that is not captured
+in the eigenvectors.
 """
-function variation(o::CCIPCA)
+function relativevariances(o::CCIPCA)
     if o.n == 0
         return zeros(Float64, outdim(o))
     else

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -25,12 +25,18 @@ approximation to (batch) PCA.
 
 # Example
 
-    o = CCIPCA(10, 2)     # Project 10-dimensional vectors into 2D
-    fit!(o, rand(10))
-    fit!(o, rand(10))
-    OnlineStats.transform(o, rand(10))
-    sort!(o)              # Sort from high to low eigenvalues
-    o[1]                  # Get primary (1st) eigenvector
+    o = CCIPCA(10, 2)                # Project 10-dimensional vectors into 2D
+    u1 = rand(10)
+    fit!(o, u1)                      # Fit to u1
+    u2 = rand(10)
+    fit!(o, u2)                      # Fit to u2
+    u3 = rand(10)
+    OnlineStats.transform(o, u3)     # Project u3 into PCA space fitted to u1 and u2 but don't change the projection
+    u4 = rand(10)
+    OnlineStats.fittransform!(o, u4) # Fit u4 and then project u4 into the space
+    sort!(o)                         # Sort from high to low eigenvalues
+    o[1]                             # Get primary (1st) eigenvector
+    OnlineStats.variation(o)         # Get the variation (explained) "by" each eigenvector
 """
 mutable struct CCIPCA <: OnlineStat{Vector{Float64}}
     U::Matrix{Float64}      # Eigenvectors, one row per indim, one column per outdim

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -9,13 +9,13 @@
 # High Dimension: Which Algorithm to Choose?", Int. Statistical Review, 2018-
 
 """
-    CCIPCA(outdim::Int, indim::Int; l::Int)
+    CCIPCA(indim::Int, outdim::Int; l::Int)
 
 Online PCA with the CCIPCA (Candid Covariance-free Incremental PCA) algorithm,
-where outdim is the number of dimension to project to, indim is the length
-of incoming vectors, and l is the level of amnesia. Give values in the range
-2-4 of l if you want old vectors to be gradually less important, i.e.
-latest vectors added get more weight.
+where indim is the length of incoming vectors, outdim is the number of dimension 
+to project to, , and l is the level of amnesia. Give values of l in the range
+2-4 if you want old vectors to be gradually less important, i.e. latest vectors 
+added get more weight.
 
 This is a very fast, simple, and online approximation of PCA. It can be used
 for Dimensionality Reduction to project high-dimensional vectors into a 

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -64,7 +64,7 @@ function _fit!(o::CCIPCA, x::Vector{Float64})
     n = o.n + 1
     # update center with new observation:
     #o.center = (o.n * o.center .+ x)/n
-    o.center += (x .- o.center)/n
+    o.center += (x .- o.center) ./ n
     # center the new observation, unless this is the first observation:
     xi = (o.n > 0) ? (x .- o.center) : deepcopy(x)
     # Now recalc eigen-values and -vectors given the new observation:

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -12,10 +12,10 @@
     CCIPCA(indim::Int, outdim::Int; l::Int)
 
 Online PCA with the CCIPCA (Candid Covariance-free Incremental PCA) algorithm,
-where indim is the length of incoming vectors, outdim is the number of dimension 
-to project to, , and l is the level of amnesia. Give values of l in the range
-2-4 if you want old vectors to be gradually less important, i.e. latest vectors 
-added get more weight.
+where indim is the length of incoming vectors, outdim is the number of 
+dimension to project to, and l is the level of amnesia. Give values of l in 
+the range 2-4 if you want old vectors to be gradually less important, i.e. 
+latest vectors added get more weight.
 
 This is a very fast, simple, and online approximation of PCA. It can be used
 for Dimensionality Reduction to project high-dimensional vectors into a 

--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -92,6 +92,8 @@ function transform(o::CCIPCA, u::AbstractArray{Float64})
     @assert indim(o) == length(u)
     (u .- o.center)' * o.U
 end
+# We can also call the CCIPCA object itself to transform:
+(o::CCIPCA)(u::AbstractArray{Float64}) = transform(o, u)
 """
     reconstruct(o::CCIPCA, uproj::AbstractArray{Float64})
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -464,6 +464,10 @@ end
         println()
     end
 end
+#-----------------------------------------------------------------------# CCIPCA
+@testset "CCIPCA" begin
+    include("test_ccipca.jl")
+end
 #-----------------------------------------------------------------------# Kahan
 
 include("test_kahan.jl")

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -11,8 +11,8 @@
     @test OnlineStats.eigenvalue(o, 1) == 0.0
     @test OnlineStats.eigenvalue(o, 2) == 0.0
 
-    # variation is also a vector of zeros before we fit any values:
-    @test OnlineStats.variation(o) == zeros(Float64, 2)
+    # relativevariances is also a vector of zeros before we fit any values:
+    @test OnlineStats.relativevariances(o) == zeros(Float64, 2)
 
     # first vector added goes straight into the projection matrix:
     u1 = rand(4)
@@ -150,7 +150,7 @@ end
     end
 end
 
-@testset "sort! and variation (random testing)" begin
+@testset "sort! and relativevariances (random testing)" begin
     for _ in 1:10
         o, us = setup_ccipca_randomly(4:42, 25)
         lambdapre = deepcopy(o.lambda)
@@ -167,8 +167,8 @@ end
             @test OnlineStats.eigenvector(o, i) == Upre[:, idx]
         end
 
-        # Ensure variation is also sorted and has valid ranges
-        v = OnlineStats.variation(o)
+        # Ensure relativevariances is also sorted and has valid ranges
+        v = OnlineStats.relativevariances(o)
         @test length(v) == OnlineStats.outdim(o)
         @test isapprox(sum(v), 1.0; atol=1e-4)
         for i in 1:(OnlineStats.outdim(o)-1)

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -105,7 +105,7 @@ function setup_ccipca_randomly(indimrange = 4:100, maxn = 200;
     return o, us
 end
 
-@testset "fit!+transform+reconstruct == fittransform!+reconstruct" begin
+@testset "fit!+transform == fittransform! and callable (random testing)" begin
     function test_f!tr_equals_ft!r(o1, o2, u)
         fit!(o1, u)
         uproj1 = OnlineStats.transform(o1, u)
@@ -115,6 +115,10 @@ end
 
         @test uproj1 == uproj2
         @test urec1 == urec2
+
+        # calling the ccipca object is same as transform
+        uproj1b = o1(u)
+        @test uproj1b == uproj1 
     end
 
     # Random testing with different indims and outdims

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -1,0 +1,114 @@
+@testset "CCIPCA basic tests" begin
+    o = CCIPCA(4, 2)
+    @test OnlineStats.outdim(o) == 2
+    @test OnlineStats.indim(o)  == 4
+    @test size(o)               == (4, 2)
+
+    # eigen-vectors and eigen-values are 0 before we fit any values:
+    @test o[1] == zeros(Float64, 4)
+    @test o[2] == zeros(Float64, 4)
+    @test OnlineStats.eigenvalue(o, 1) == 0.0
+    @test OnlineStats.eigenvalue(o, 2) == 0.0
+
+    # first vectors added goes straight into the projection matrix:
+    u1 = rand(4)
+    fit!(o, u1)
+    @test o[1] == u1/norm(u1)
+    @test o[2] == zeros(Float64, 4)
+
+    # We can get eigen-values individually or in array:
+    @test length(OnlineStats.eigenvalues(o)) == 2
+    @test OnlineStats.eigenvalues(o)[1] == OnlineStats.eigenvalue(o, 1)
+    @test OnlineStats.eigenvalues(o)[2] == OnlineStats.eigenvalue(o,     2)
+
+    # errors if asking for eigen-values or vectors outside of outdim range:
+    @test_throws AssertionError OnlineStats.eigenvalue(o, 3)
+    @test_throws AssertionError OnlineStats.eigenvalue(o, 0)
+    @test_throws AssertionError OnlineStats.eigenvalue(o,   -1)
+
+    # errors if trying to fit vector of wrong length:
+    @test_throws AssertionError fit!(o, rand(3))
+    @test_throws AssertionError fit!(o, rand(   5  ) )
+end # @testset "CCIPCA basic tests" begin
+
+@testset "fit!+transform+reconstruct == fittransform!+reconstruct" begin
+
+    function test_f!tr_equals_ft!r(o1, o2, u)
+        fit!(o1, u)
+        uproj1 = OnlineStats.transform(o1, u)
+        urec1  = OnlineStats.reconstruct(o1, uproj1)
+        uproj2 = OnlineStats.fittransform!(o2, u)
+        urec2 = OnlineStats.reconstruct(o2, uproj2)
+
+        @test uproj1 == uproj2
+        @test urec1 == urec2
+    end
+
+    # Random testing with different indims and outdims
+    for _ in 1:10
+        indim = rand(4:100)
+        outdim = rand(1:(indim-1))
+        o1 = CCIPCA(indim, outdim)
+        o2 = CCIPCA(indim, outdim)
+
+        for _ in 1:rand(1:10)
+            u = rand(0.01:0.01:42.42) * rand(indim)
+            test_f!tr_equals_ft!r(o1, o2, u)
+        end
+    end
+end
+
+@testset "Differential test #1 with onlinePCA R package" begin
+    # Differential testing with onlinePCA package in R:
+    #   lambda <- c(0.0, 0.0)
+    #   U <- matrix(rep.int(0, 2*4), nrow = 4, ncol = 2)
+    #   library(onlinePCA)
+    o = CCIPCA(4, 2)
+
+    #   u1 <- c(1.0, 2.0, 3.0, 4.0)
+    u1 = [1.0, 2.0, 3.0, 4.0]
+    #   r1 <- ccipca(lambda, U, u1, 0, q=2, l=0);
+    fit!(o, u1)
+    #   r1$values[1]  # => 5.477226
+    @test OnlineStats.eigenvalues(o)[1] ≈ 5.477225575
+    ev1 = OnlineStats.eigenvector(o, 1)
+    #   r1$vectors[1] # => 0.1825742
+    @test isapprox(ev1[1], 0.1825742; atol = 1e-7)
+    #   r1$vectors[2] # => 0.3651484
+    @test isapprox(ev1[2], 0.3651484; atol = 1e-7)
+    #   r1$vectors[3] # => 0.5477226
+    @test isapprox(ev1[3], 0.5477226; atol = 1e-7)
+    #   r1$vectors[4] # => 0.7302967
+    @test isapprox(ev1[4], 0.7302967; atol = 1e-7)
+    # Since we have only added one value so far, the 2nd eigenvector is 0
+    @test OnlineStats.eigenvector(o, 2) == zeros(Float64, 4)
+
+    #   u2 <- c(3.1, 2.7, 5.6, 3.0)
+    u2 = [3.1, 2.7, 5.6, 3.0]
+    #   xbar <- (u1 + u2)/2
+    #   r2 <- ccipca(r1$values, r1$vectors, u2, 1, q=2, l=0, center = xbar);
+    fit!(o, u2)
+    #   r2$values[1]  # => 3.011238
+    @test isapprox(OnlineStats.eigenvalues(o)[1], 3.011238; atol = 1e-6)
+    ev1 = OnlineStats.eigenvector(o, 1)
+    #   r2$vectors[1,1] # => 0.2822287
+    @test isapprox(ev1[1], 0.2822287; atol = 1e-6)
+    #   r2$vectors[2,1] # => 0.3708174
+    @test isapprox(ev1[2], 0.3708174; atol = 1e-6)
+    #   r1$vectors[3,1] # => 0.6419809
+    @test isapprox(ev1[3], 0.6419809; atol = 1e-6)
+    #   r1$vectors[4,1] # => 0.6088530
+    @test isapprox(ev1[4], 0.6088530; atol = 1e-6)
+
+    #   r2$values[2]  # => 1.500179
+    @test isapprox(OnlineStats.eigenvalues(o)[2], 1.500179; atol = 1e-6)
+    ev2 = OnlineStats.eigenvector(o, 2)
+    #   r2$vectors[1,2] # => 0.520012308
+    @test isapprox(ev2[1], 0.520012308; atol = 1e-6)
+    #   r2$vectors[2,2] # => -0.003068536
+    @test isapprox(ev2[2], -0.003068536; atol = 1e-6)
+    #   r1$vectors[3,2] # => 0.457338448
+    @test isapprox(ev2[3], 0.457338448; atol = 1e-6)
+    #   r1$vectors[4,2] # => -0.721400948
+    @test isapprox(ev2[4], -0.721400948; atol = 1e-6)
+end # @testset "Differential test with onlinePCA R package" begin

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -10,7 +10,7 @@
     @test OnlineStats.eigenvalue(o, 1) == 0.0
     @test OnlineStats.eigenvalue(o, 2) == 0.0
 
-    # first vectors added goes straight into the projection matrix:
+    # first vector added goes straight into the projection matrix:
     u1 = rand(4)
     fit!(o, u1)
     @test o[1] == u1/norm(u1)
@@ -19,16 +19,16 @@
     # We can get eigen-values individually or in array:
     @test length(OnlineStats.eigenvalues(o)) == 2
     @test OnlineStats.eigenvalues(o)[1] == OnlineStats.eigenvalue(o, 1)
-    @test OnlineStats.eigenvalues(o)[2] == OnlineStats.eigenvalue(o,     2)
+    @test OnlineStats.eigenvalues(o)[2] == OnlineStats.eigenvalue(o, 2)
 
     # errors if asking for eigen-values or vectors outside of outdim range:
-    @test_throws AssertionError OnlineStats.eigenvalue(o, 3)
-    @test_throws AssertionError OnlineStats.eigenvalue(o, 0)
-    @test_throws AssertionError OnlineStats.eigenvalue(o,   -1)
+    @test_throws AssertionError OnlineStats.eigenvalue(o,  3)
+    @test_throws AssertionError OnlineStats.eigenvalue(o,  0)
+    @test_throws AssertionError OnlineStats.eigenvalue(o, -1)
 
     # errors if trying to fit vector of wrong length:
     @test_throws AssertionError fit!(o, rand(3))
-    @test_throws AssertionError fit!(o, rand(   5  ) )
+    @test_throws AssertionError fit!(o, rand(5))
 end # @testset "CCIPCA basic tests" begin
 
 @testset "fit!+transform+reconstruct == fittransform!+reconstruct" begin

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -3,7 +3,8 @@
     @test OnlineStats.outdim(o) == 2
     @test OnlineStats.indim(o)  == 4
     @test size(o)               == (4, 2)
-
+    @test length(o) == lastindex(o) == 2
+    
     # eigen-vectors and eigen-values are 0 before we fit any values:
     @test o[1] == zeros(Float64, 4)
     @test o[2] == zeros(Float64, 4)


### PR DESCRIPTION
This implements the CCIPCA (Candid Covariance-free Incremental PCA) algorithm which is a fast, approximate PCA. Also has quite extensive tests including differential testing with the CCIPCA implementation of the R package onlinePCA. I also propose to export the transform method from OnlineStats but I have NOT done so in this PR.