### PR TITLE
Link ThreadsX.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ MIT - see the [LICENSE](LICENSE) file.
 - [JuliaDB](https://github.com/JuliaComputing/JuliaDB.jl)
 - [Pathogen](https://github.com/jangevaare/Pathogen.jl)
 - [Recombinase](https://github.com/piever/Recombinase.jl)
-- [Transducers](https://github.com/tkf/Transducers.jl)
+- [ThreadsX](https://github.com/tkf/ThreadsX.jl)
+- [Transducers](https://github.com/JuliaFolds/Transducers.jl)
 - [WeightedOnlineStats](https://github.com/gdkrmr/WeightedOnlineStats.jl)


### PR DESCRIPTION
ThreadsX.jl provides [an easy-to-use interface for threaded reduction with OnlineStats.jl](https://github.com/tkf/ThreadsX.jl#onlinestatsjl) on top of Transducers.jl.  I wonder if it is appropriate to mention it in the README.

I also fixed the link to Transducers.jl.
