### PR TITLE
fix HyperLogLog leading zeros

### DIFF
--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -257,12 +257,13 @@ function Base.show(io::IO, o::HyperLogLog{p,T}) where {p,T}
     print(io, "HyperLogLog{$p, $T}: n=$(nobs(o)) | value=", value(o))
 end
 
-function _fit!(o::HyperLogLog, v)
+function _fit!(o::HyperLogLog{p}, v) where {p}
     o.n += 1
     x = hash(v) % UInt32
     i = (x & mask(o)) + UInt32(1)
     w = (x & ~mask(o))
-    o.M[i] = max(o.M[i], UInt32(leading_zeros(w) + 1))
+    nzeros = min(leading_zeros(w), 32 - p)
+    o.M[i] = max(o.M[i], UInt32(nzeros + 1))
 end
 
 function value(o::HyperLogLog)


### PR DESCRIPTION
# Summary
This pull request solves a little mistake in the `_fit!` method for `HyperLogLog`.

# Explanation
The algorithm uses a 32 bit hash code, with `p` bits reserved to indicate the register to update. The other `q` (`= 32 - p`) bits are used to determine the number of leading zeros. The problem in the current implementation is that if all bits are zero then the result of `leading_zeros(w)` will be `32` instead of the desired value `q`, because the object `w` is a `UInt32` with the last `p` bits set to zero.

# Effect
By construction this problem happens for very large cardinalities, close to the limit 2^32 where the HyperLogLog algorithm is in any case hitting its limitations. So the bias introduced by this mistake is in practice very small.

# Context
This was found in the context of https://github.com/joshday/OnlineStats.jl/issues/177. After this is merged I plan to open a pull request that implements the improved estimator suggested in that issue.