### PR TITLE
improved HyperLogLog estimator

### DIFF
--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -310,7 +310,7 @@ function _improved_estimator(o::HyperLogLog)
         z = (z + C_k) / 2
     end
     z += m * σ(C[1] / m)
-    return m^2 / z / (2log(2))
+    return m^2.0 / z / (2log(2))
 end
 
 function _merge!(o::HyperLogLog, o2::HyperLogLog)


### PR DESCRIPTION
# Summary

This pull request implements the improved HyperLogLog  estimator as suggested in https://github.com/joshday/OnlineStats.jl/issues/177.

# Implementation details

The existing `fit!` and `merge!` methods for the HyperLogLog  OnlineStat remain the same, and only the HyperLogLog estimator (i.e. `value` method)  changes. The improved estimator is returned by default, but the original estimator can be obtained using the `original_estimator=true` option.

The chosen implementation for sigma and tau does not follow exactly the implementation suggested by @StefanKarpinski in #177. It rather follows *Algorithm 6* as described in detail in https://arxiv.org/pdf/1702.01284.pdf, which is pretty efficient as discussed in the paper. In particular sigma and tau are not precalculated for all possible values of C_k. The reason for that is that they would need to be precalculated also for all possible choices of `p`, plus performance doesn't seem to be a problem as shown next.

# Performance

The improved estimator seems to be fairly fast even with the calculation on demand of sigma and tau, and as shown below it's actually faster than the original estimator:
```julia
julia> using OnlineStats, BenchmarkTools

julia> o = HyperLogLog()
HyperLogLog{16, Number}: n=0 | value=0.0

julia> fit!(o, rand(1:2^30, 10^6))
HyperLogLog{16, Number}: n=1000000 | value=1.0102656179661168e6

julia> @btime value(o)
  50.683 μs (3 allocations: 448 bytes)
1.0102656179661168e6

julia> @btime value(o; original_estimator=true)
  1.013 ms (2 allocations: 32 bytes)
1.010182404846571e6
```

# Original vs Improved estimator error

As a validation of the improved estimator, we compare below the original estimator and the improved one as a function of the true cardinality:

![cardinality_zoom](https://user-images.githubusercontent.com/4679015/89839666-3b85e800-db66-11ea-8009-ddfe6e2d8977.png)

![cardinality](https://user-images.githubusercontent.com/4679015/89839686-4a6c9a80-db66-11ea-9ef6-22d115d50a10.png)

As expected we observed that the improved estimator does better in the regions of large cardinality and cardinality around *5m/2* where the original estimator is known to be biased.

# Possible further improvements

Other possible quick improvements to the HyperLogLog current implementation are:
- Use a 64 bits hash code instead of 32. This should be fairly easy and allows to calculate cardinalities larger than 2^32.
- Use minimal space required for registers. Currently the registers stored in the vector `M` are 64 bit integers, while only `q` bits (32 - p) are needed. 
