### PR TITLE
Fix inequality in reservoir sampling

### DIFF
--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -784,7 +784,7 @@ function _fit!(o::ReservoirSample, y)
         o.value[o.n] = y
     else
         j = rand(1:o.n)
-        if j < length(o.value)
+        if j <= length(o.value)
             o.value[j] = y
         end
     end


### PR DESCRIPTION
I noticed the reservoir sampling was never reassigning the `k`th element, this is just a single letter fix.

Up: before MR
Below: after
![image](https://user-images.githubusercontent.com/2074313/99186540-30d48380-2751-11eb-9dc7-a98bccbd83b0.png)
