### PR TITLE
tried to make StatLearn more discoverable in docs

### DIFF
--- a/docs/src/stats_and_models.md
+++ b/docs/src/stats_and_models.md
@@ -85,5 +85,30 @@
 | Statistic/Model                    | OnlineStat                 |
 |:-----------------------------------|:---------------------------|
 | Univariate data stream             | [`Series`](@ref), [`FTSeries`](@ref) |
-| Multivariate data streams          | [`Group`](@ref)
+| Multivariate data streams          | [`Group`](@ref)            |
 | Group by categorical variable      | [`GroupBy`](@ref)          |
+
+## Machine Learning
+
+| Statistic/Model                    | OnlineStat                 |
+|:-----------------------------------|:---------------------------|
+| Linear SGD                         | [`StatLearn`](@ref)        |
+
+### Regression and Classification Losses
+
+| Loss                               | Function                   |
+|:-----------------------------------|:---------------------------|
+| ``L_{2}`` Loss (squared error)     | [`l2regloss`](@ref)        |
+| ``L_{1}`` Loss (absolute error)    | [`l1regloss`](@ref)        |
+| Logistic Loss                      | [`logisticloss`](@ref)     |
+| ``L_{1}`` Hinge Loss               | [`l1hingeloss`](@ref)      |
+| Generalized distance weighted discrimination | [`DWDLoss`](@ref)|
+
+### Optimization Algorithms
+
+| Algorithm                               | Constructor           |
+|:----------------------------------------|:----------------------|
+| Stochastic Gradient Descent             | [`SGD`](@ref)         |
+| Majorization Minimization (averaged surrogate) | [`OMAS`](@ref) |
+| Majorization Minimization (averaged parameter) | [`OMAP`](@ref) |
+


### PR DESCRIPTION
Hello!  I'm only now realizing quite how awesome this package is.  Even though there is a ton of (great!) documentation, a few things are a bit buried and I almost didn't realize they existed.

Especially `StatLearn`, that seems like kind of a big deal.

This adds `StatLearn` and its possible arguments to a dedicated new section of the "Stats and Models" section of the docs.  I tried to make this consistent with the existing format, but please feel free to suggest changes.