### PR TITLE
ReservoirSample with generic type

### DIFF
--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -770,12 +770,15 @@ the probability of an observation being in the sample is `1 / n`.
 
     fit!(ReservoirSample(100, Int), 1:1000)
 """
-mutable struct ReservoirSample{T<:Number} <: OnlineStat{Number}
+mutable struct ReservoirSample{T} <: OnlineStat{T}
     value::Vector{T}
     n::Int
 end
 function ReservoirSample(k::Int, T::Type = Float64)
     ReservoirSample(zeros(T, k), 0)
+end
+function ReservoirSample(k::Int, T::Type{<:AbstractString})
+    ReservoirSample(fill(T(""), k), 0)
 end
 function _fit!(o::ReservoirSample, y)
     o.n += 1


### PR DESCRIPTION
Currently `ReservoirSample` only accept `Number` types and implements a constructor based on `zeros`.

This PR changes `ReservoirSample` so it can accept any generic type `T`, and implements a constructor for `AbstractString` types using empty strings. Other types that implement the method `zero` (e.g. `TimeTypes`) will work.