### PR TITLE
Add `TopK`

### DIFF
--- a/src/OnlineStats.jl
+++ b/src/OnlineStats.jl
@@ -52,7 +52,7 @@ export
     Quantile,
     ReservoirSample,
     Series, SGDStat, StatLag, StatLearn, Sum,
-    Trace,
+    TopK, Trace,
     Variance,
 # other
     OnlineStat, BiasVec

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,6 +416,21 @@ end
         @test yi in 'a':'z'
     end
 end
+#-----------------------------------------------------------------------# TopK
+@testset "TopK" begin
+    @test value(TopK(1)) == [-Inf]
+    @test value(fit!(TopK(2, Int), shuffle(1:10))) == [9, 10]
+    @test nobs(fit!(TopK(2, Int), shuffle(1:10))) == 10
+    a, b = mergestats(TopK(10), y, y2)
+    @test value(a) == value(b)
+
+    @test value(TopK(1; rev=true)) == [Inf]
+    @test value(fit!(TopK(2, Int, rev=true), shuffle(1:10))) == [2, 1]
+    a, b = mergestats(TopK(20; rev=true), y, y2)
+    @test value(a) == value(b)
+
+    @test_throws ArgumentError merge(fit!(TopK(2, Int), 1:10), fit!(TopK(2, Int; rev=true), 1:10))
+end
 #-----------------------------------------------------------------------# LogSumExp
 @testset "LogSumExp" begin
     @test value(LogSumExp()) == -Inf


### PR DESCRIPTION
This wants to add a way to keep the largest `k` elements. 

Many ways to do this were recently timed here:
https://discourse.julialang.org/t/maintaining-a-fixed-size-top-n-values-list/78868/15
This matches the simplest implementation there. It's possible that the slight gains of the others are worth it, although on my computer they don't seem to be visible, on that example.

However, the `mutable struct` with `o.n += 1` at every step seems to make a huge difference. Is this expected, and or is there a way around it?  
```julia
julia> v1 = init1(N); v1 = min_values1(N, x, v1); v11 = init1(N);

julia> @btime min_values1($N, $x, $v11);
  10.270 ms (0 allocations: 0 bytes)

julia> v4 = init4(N); v4 = min_values4(N, x, v4); @assert last(v1) == last(v4); v44 = init4(N);

julia> @btime min_values4($N, $x, $v44);
  10.370 ms (0 allocations: 0 bytes)

julia> v6 = init6(N); v6 = min_values6(N, x, v6);

julia> @btime min_values6($N, $x, $v66);
  10.248 ms (0 allocations: 0 bytes)

# This PR:

julia> v7 = fit!(TopK(N; rev=true), x).value;

julia> @assert sort(v7) == sort(v1)

julia> @btime fit!($(TopK(N; rev=true)), $x);
  33.560 ms (0 allocations: 0 bytes)
  15.436 ms (0 allocations: 0 bytes)  # without o.n += 1 step
  10.273 ms (0 allocations: 0 bytes)  # with immutable struct, and without o.n += 1
```