### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OnlineStats"
 uuid = "a15396b6-48d5-5d58-9928-6d29437db91e"
-version = "1.5.13"
+version = "1.5.14"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
-OnlineStatsBase = "1.4.7"
+OnlineStatsBase = "1.4.7, 1.5"
 OrderedCollections = "1.1"
 RecipesBase = "0.7, 0.8, 1.0, 1.1"
 StatsBase = "0.32, 0.33"


### PR DESCRIPTION
`OnlineStatsBase@v1.5` supports `AbstractTree@v0.4` now. The current version downgrades that dependency.