### PR TITLE
fix type stability in autocov and add a unit test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OnlineStats"
 uuid = "a15396b6-48d5-5d58-9928-6d29437db91e"
-version = "1.6.3"
+version = "1.6.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -53,13 +53,13 @@ struct AutoCov{T, W} <: OnlineStat{Number}
     cross::Vector{Float64}
     m1::Vector{Float64}
     m2::Vector{Float64}
-    lag::CircBuff{T}         # y_{t-1}, y_{t-2}, ...
-    wlag::CircBuff{Float64}  # γ_{t-1}, γ_{t-2}, ...
-    v::Variance{W}
+    lag::CircBuff{T, true}         # y_{t-1}, y_{t-2}, ...
+    wlag::CircBuff{Float64, true}  # γ_{t-1}, γ_{t-2}, ...
+    v::Variance{T, T, W}
 end
 function AutoCov(k::Integer, T = Float64; kw...)
     d = k + 1
-    AutoCov(zeros(d), zeros(d), zeros(d), CircBuff(T,d;rev=true), CircBuff(Float64,d;rev=true), Variance(;kw...))
+    AutoCov(zeros(d), zeros(d), zeros(d), CircBuff(T,d;rev=true), CircBuff(Float64,d;rev=true), Variance(T, ;kw...))
 end
 nobs(o::AutoCov) = nobs(o.v)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,17 @@ mergevals(o1::OnlineStat, y1, y2) = map(value, mergestats(o1, y1, y2))
     @test autocov(o) ≈ autocov(y, 0:10)
     @test autocor(o) ≈ autocor(y, 0:10)
     @test nobs(o) == n
+    # validate type stability
+    # we cannot do @inferred o.cross or @inferred getfield(o, :cross) directly
+    # because that does not do constant propagation. So we need a function barrier
+    # Furthermore, since @inferred either throws or returns the result, we need to
+    # test if for equality manually.
+    @test (@inferred ((o) -> o.cross)(o)) === o.cross
+    @test (@inferred ((o) -> o.m1)(o))    === o.m1
+    @test (@inferred ((o) -> o.m2)(o))    === o.m2
+    @test (@inferred ((o) -> o.lag)(o))   === o.lag
+    @test (@inferred ((o) -> o.wlag)(o))  === o.wlag
+    @test (@inferred ((o) -> o.v)(o))     === o.v
 end
 #-----------------------------------------------------------------------# Bootstrap
 @testset "Bootstrap" begin


### PR DESCRIPTION
Fixes https://github.com/joshday/OnlineStats.jl/issues/269

I tried to make the test a bit less copy-pasta with 
```julia
for property in (:cross, :m1, :m2, :lag, :wlag, :v)
    @eval begin
        @test (@inferred ((o) -> o.property)(o)) === o.property
    end
end
```
but unfortunately, that doesn't work since `@eval` always works in global scope, so I just copy-pasted it.

You can test that this solves the issue with `_fit!` by running:

```julia
@code_warntype OnlineStats._fit!(AutoCov(10), randn(100))
```

Suggestions, comments, and feedback are welcome!