### PR TITLE
Add the "Robust peak detection algorithm (using z-scores)" from SO.

### DIFF
--- a/src/OnlineStats.jl
+++ b/src/OnlineStats.jl
@@ -54,6 +54,7 @@ export
     Trace,
     Variance,
     DPMM,
+    ZScoreDetector,
 # other
     OnlineStat, BiasVec
 
@@ -109,6 +110,7 @@ include("stats/pca.jl")
 include("stats/statlearn.jl")
 include("stats/trace.jl")
 include("stats/dpmm.jl")
+include("stats/peak_detection.jl")
 #-----------------------------------------------------------------------------# viz
 include("viz/khist.jl")
 include("viz/khist2d.jl")

--- a/src/stats/peak_detection.jl
+++ b/src/stats/peak_detection.jl
@@ -42,7 +42,7 @@ function _fit!(o::ZScoreDetector{T}, y::Real) where {T}
         o.signal = 0
         fit!(o.filtered, y)
     else
-        if abs(y - o.center) > o.threshold * o.stds
+        if abs(y - o.center) > (o.threshold * o.stds)
             y > o.center ? (o.signal = 1) : (o.signal = -1)
             fit!(o.filtered, o.influence * y + (1 - o.influence) * o.filtered[end])
         else

--- a/src/stats/peak_detection.jl
+++ b/src/stats/peak_detection.jl
@@ -1,0 +1,56 @@
+"""
+    ZScoreDetector(lag::Int, threshold::T, influence::T, T = Float64) where
+
+Applies the *robust peak detection [...] using z-scores* algorithm to the incoming datastream. 
+
+
+# Source
+    Brakel, J.P.G. van (2014). "Robust peak detection algorithm using z-scores". Stack Overflow. 
+    Available at: https://stackoverflow.com/questions/22583391/peak-signal-detection-in-realtime-timeseries-data/22640362#22640362 
+    (version: 2020-11-08).
+
+# Example
+    o = ZScoreDetector(30,3.0,0.5)
+    fit!(o, 1:12)
+    o.signal # signal at last observation
+"""
+mutable struct ZScoreDetector{T} <: OnlineStat{Number}
+    n::Int
+    lag::Int
+    threshold::T
+    influence::T
+    center::T
+    stds::T
+    signal::Int
+    filtered::CircBuff{T}
+end
+
+function ZScoreDetector(lag, threshold, influence, T=Float64)
+    @assert threshold > 0 "Threshold needs to be positive."
+    @assert lag >= 1 "Lag needs to be >=1"
+    ZScoreDetector{T}(0, lag, threshold, influence, 0, 0, 0, CircBuff(T, lag, rev=false))
+end
+
+Base.length(o::ZScoreDetector) = o.n
+nobs(o::ZScoreDetector) = o.n
+value(o::ZScoreDetector) = o.signal
+
+function _fit!(o::ZScoreDetector{T}, y::Real) where {T}
+    y = convert(T, y)
+    n = o.n + 1
+    if n < o.lag
+        o.signal = 0
+        fit!(o.filtered, y)
+    else
+        if abs(y - o.center) > o.threshold * o.stds
+            y > o.center ? (o.signal = 1) : (o.signal = -1)
+            fit!(o.filtered, o.influence * y + (1 - o.influence) * o.filtered[end])
+        else
+            o.signal = 0
+            fit!(o.filtered, y)
+        end
+        o.center = mean(o.filtered.value)
+        o.stds = std(o.filtered.value)
+    end
+    o.n += 1
+end


### PR DESCRIPTION
Hi dear Maintainers,

thanks again for the great package - as I have profited from it greatly I wanted to give something back - by adding a new Algorithm.

I have been using the algorithm from the merge request myself quite a bit. 
It is able to do peak detection in univariate real-time timeseries.
AFAIK the algorithm has been made public under attribution.

The source would be:

> Brakel, J.P.G. van (2014). "Robust peak detection algorithm using z-scores". Stack Overflow. Available at: https://stackoverflow.com/questions/22583391/peak-signal-detection-in-realtime-timeseries-data/22640362#22640362 (version: 2020-11-08).

I am currently in the process of extending it (multivariate use case) - and would likely be able and willing to add the extensions as well, as I see this package as a great fit for these algorithms.

Let me know what I would need to do to make this fit both in spirit and in line with code standards of your package.

~hv10

EDIT: The algorithm(s) are also online and take constant memory.