### PR TITLE
Fix 291

### DIFF
--- a/src/stats/pca.jl
+++ b/src/stats/pca.jl
@@ -100,12 +100,12 @@ function _fit!(o::CCIPCA, x::AbstractVector{<:Real})
     @inbounds for i in 1:outdim(o)
         if i == n
             o.lambda[i] = norm(o.xi)
-            o.U[:, i] = o.xi / o.lambda[i]
+            o.U[:, i] = o.xi / (o.lambda[i]+OnlineStats.ϵ)
             break
         end
         o.v = (1-f) * o.lambda[i] * o.U[:, i] + f * dot(o.U[:, i], o.xi) * o.xi
         o.lambda[i] = norm(o.v)
-        o.U[:, i] = o.v/o.lambda[i]
+        o.U[:, i] = o.v/(o.lambda[i]+OnlineStats.ϵ)
         o.xi = o.xi .- (dot(o.U[:, i], o.xi) * o.U[:, i])
     end
     o.n = n

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -17,7 +17,7 @@
     # first vector added goes straight into the projection matrix:
     u1 = rand(4)
     fit!(o, u1)
-    @test o[1] == u1/norm(u1)
+    @test isapprox(o[1], u1/norm(u1); atol=1e-6)
     @test o[2] == zeros(Float64, 4)
 
     # We can get eigen-values individually or in array:

--- a/test/test_ccipca.jl
+++ b/test/test_ccipca.jl
@@ -177,3 +177,13 @@ end
         end
     end
 end
+
+@testset "Is CCIPCA resistant against accidental misuse?" begin
+    o = CCIPCA(2, 4)
+    u1 = rand(4)
+    # if we repeatedly fit with the same vector 
+    # we should not fail by having an eigenval of NaN
+    fit!(o, u1)
+    fit!(o, u1)
+    @test !any(isnan.(OnlineStats.eigenvalues(o)))
+end


### PR DESCRIPTION
This is an attempt to fix #291 

The solution I came up with after adding a test for my specific issue is to avoid the division by zero by adding OnlineStats.$\epsilon$ to the offending lines.

Only downside:
The basic test has to be modified to accept a solution which is slightly wrong (by $\epsilon$) instead of an exact match.

Aside from this it came up green for any other tests.