### PR TITLE
Expose extrema of OrderStats

### DIFF
--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -451,6 +451,12 @@ function ecdf(o::OrderStats)
     ecdf(vcat(a, value(o), b))
 end
 
+Extrema(o::OrderStats) = copy(o.ex)
+Base.minimum(o::OrderStats) = Base.minimum(o.ex)
+Base.extrema(o::OrderStats) = Base.extrema(o.ex)
+Base.maximum(o::OrderStats) = Base.maximum(o.ex)
+Base.convert(::Type{Extrema}, o::OrderStats) = Extrema(o)
+
 # # tree/nbc help:
 # function pdf(o::OrderStats, x)
 #     if x ≤ first(o.value)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -387,6 +387,17 @@ end
     o = fit!(OrderStats(n), y)
     @test value(o) == sort(y)
     @test quantile(o, 0:.25:1) == quantile(y, 0:.25:1)
+    _min = minimum(o)
+    _max = maximum(o)
+    _ex = Extrema(o)
+    @test extrema(o) == (_min, _max)
+    @test extrema(o) == extrema(_ex)
+    @test _min <= quantile(o, 0)
+    @test _max >= quantile(o, 1)
+    @test convert(Extrema, o) == _ex
+    fit!(_ex, _max + oneunit(_max))
+    fit!(_ex, _min - oneunit(_min))
+    @test extrema(o) != extrema(_ex)
 end
 #-----------------------------------------------------------------------# Partition
 @testset "Partition" begin


### PR DESCRIPTION
OrderStats is currently implemented using an internal `Extrema` statistic. Would it make sense to expose that?

Specifically, we could implement:
* `Base.minimum`
* `Base.maximum`
* `Base.extrema`
* Conversion to `Extrema`, which creates a copy of the internal `Extrema`
