### PR TITLE
Fix warning on Julia 1.12-nightly

### DIFF
--- a/src/OnlineStats.jl
+++ b/src/OnlineStats.jl
@@ -3,7 +3,7 @@ module OnlineStats
 using Statistics, LinearAlgebra, Dates
 
 import OnlineStatsBase: value, name, _fit!, _merge!, bessel, pdf, probs, smooth, smooth!,
-    smooth_syr!, nvars, Weight, eachrow, eachcol, TwoThings
+    smooth_syr!, nvars, Weight, eachrow, eachcol, TwoThings, Extrema
 import StatsBase: fit!, nobs, autocov, autocor, confint, skewness, kurtosis, entropy, midpoints,
     fweights, sample, coef, predict, Histogram, ecdf, transform, log1p
 import StatsFuns: logsumexp


### PR DESCRIPTION
┌ OnlineStats
│  WARNING: Constructor for type "Extrema" was extended in `OnlineStats` without explicit qualification or import.
│    NOTE: Assumed "Extrema" refers to `OnlineStatsBase.Extrema`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Extrema end`.
│    Hint: To silence the warning, qualify `Extrema` as `OnlineStatsBase.Extrema` in the method signature or explicitly `import OnlineStatsBase: Extrema`.
└