### PR TITLE
ci: use aarch64 for macOS runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,12 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
+          - os: macOS-latest
+            arch: x64
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
setup-julia v3 rejects x64 on Apple Silicon macOS runners (macOS-latest is arm64). Exclude macOS x64 from the matrix and add an aarch64 entry instead, mirroring the same fix in OnlineStatsBase.